### PR TITLE
Make error.background opaque

### DIFF
--- a/themes/denix-zed-theme.json
+++ b/themes/denix-zed-theme.json
@@ -106,7 +106,7 @@
         "deleted.background": null,
         "deleted.border": null,
         "error": "#ff2e3f",
-        "error.background": "#ff2e3f38",
+        "error.background": "#4d2b32",
         "error.border": null,
         "hidden": "#abb0bf",
         "hidden.background": null,


### PR DESCRIPTION
- preserves original color when hovered over main editor buffer background

![image](https://github.com/denix666/zed-theme/assets/129/9afdc693-0a4d-4381-affd-73a825a8d094)

Fixes #1 