### PR TITLE
Make info pop-up background opaque

### DIFF
--- a/themes/denix-zed-theme.json
+++ b/themes/denix-zed-theme.json
@@ -118,7 +118,7 @@
         "ignored.background": null,
         "ignored.border": null,
         "info": "#3691ff",
-        "info.background": "#3690ff33",
+        "info.background": "#2c3a56",
         "info.border": null,
         "modified": "#5BB6FF",
         "modified.background": null,


### PR DESCRIPTION
Make info-level pop-up's background opaque, like error pop-up.

Related to #1 

![2024-06-02 zed-theme info bg](https://github.com/denix666/zed-theme/assets/129/619478ab-1991-443c-ac7a-59c5fddab354)


![image](https://github.com/denix666/zed-theme/assets/129/5d3ff9b9-c0e8-44ad-9724-715742c1f9f0)
